### PR TITLE
Fix Bug: Selecting an entry alters the query

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -3,48 +3,42 @@
 		"scope": "csharp",
 		"prefix": "info",
 		"body": [
-			"Log.Info(\"$1\", GetType());",
-			"$0"
+			"Log.Info($\"$1\", ${2:GetType()});$0",
 		],
 	},
 	"Log Error Message": {
 		"scope": "csharp",
 		"prefix": "error",
 		"body": [
-			"Log.Error(\"$1\", GetType());",
-			"$0"
+			"Log.Error($\"$1\", ${2:GetType()});$0",
 		],
 	},
 	"Log Debug Message": {
 		"scope": "csharp",
 		"prefix": "debug",
 		"body": [
-			"Log.Debug(\"$1\", GetType());",
-			"$0"
+			"Log.Debug($\"$1\", ${2:GetType()});$0",
 		],
 	},
 	"Log Warning Message": {
 		"scope": "csharp",
 		"prefix": "warning",
 		"body": [
-			"Log.Warning(\"$1\", GetType());",
-			"$0"
+			"Log.Warning($\"$1\", ${2:GetType()});$0",
 		],
 	},
 	"Log Exceptional Message": {
 		"scope": "csharp",
 		"prefix": "exception",
 		"body": [
-			"Log.Exception(\"$1\", GetType());",
-			"$0"
+			"Log.Exception($\"$1\", ${2:GetType()});$0",
 		],
 	},
 	"Show Message": {
 		"scope": "csharp",
 		"prefix": "message",
 		"body": [
-			"Context?.API.ShowMsg(\"$1\", \"$2\");",
-			"$0"
+			"Context?.API.ShowMsg($\"$1\", $\"$2\");$0",
 		],
 	},
 }

--- a/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
@@ -125,6 +125,7 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
                 // Generate Results for this Search Engine
                 results.Add(new Result
                 {
+                    QueryTextDisplay = query.Search,
                     Title = string.IsNullOrEmpty(query.Search) ? SearchEngine.Name : searchQuery,
                     SubTitle = $"Search {SearchEngine.Name}",
                     IcoPath = IconPath,

--- a/Library/Get-ProjectReferences.ps1
+++ b/Library/Get-ProjectReferences.ps1
@@ -12,6 +12,15 @@
 .EXAMPLE
     . .\Get-ProjectReferences.ps1 -Confirm
     Prompt for confirmation before copying the files.
+.EXAMPLE
+    . .\Get-ProjectReferences.ps1 -Path "C:\Program Files\PowerToys"
+    Specify the path to the PowerToys installation.
+.EXAMPLE
+    . .\Get-ProjectReferences.ps1 -Dest "C:\Projects\MyProject"
+    Specify the destination path to copy the files to.
+.EXAMPLE
+    . .\Get-ProjectReferences.ps1 -Symlink
+    Create symlinks instead of copying the files.
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -22,10 +31,13 @@ param(
 
     # Destination path to copy the files to
     [Alias("Target")]
-    [string] $Dest = $PSScriptRoot
+    [string] $Dest = $PSScriptRoot,
+
+    # Whether to create symlinks instead of copying the files
+    [switch] $Symlink
 )
 
-# The list of items to copy
+# The list of library items
 $Items = @(
     "PowerToys.Common.UI.dll",
     "PowerToys.ManagedCommon.dll",
@@ -34,9 +46,21 @@ $Items = @(
     "Wox.Plugin.dll"
 )
 
-# Copy the items to the destination
 foreach ($Item in $Items) {
+
+    # Construct the source and destination paths
     $From = Join-Path -Path $Path -ChildPath $Item
     $To = Join-Path -Path $Dest -ChildPath $Item
-    Copy-Item -Path $From -Destination $To -Force
+
+    # Remove existing files
+    Remove-Item -Path $To -Force -ErrorAction SilentlyContinue
+
+    # If $Symlink switch was provided, create a symbolic links...
+    if ($Symlink) {
+        New-Item -ItemType SymbolicLink -Path $To -Target $From -Force
+    } else {
+        # ...otherwise, copy the files to the destination
+        Copy-Item -Path $From -Destination $To -Force
+    }
+
 }


### PR DESCRIPTION
This pull request fixes the bug where selecting an entry alters the query by removing the search-engine shortcut/keyword. The fix ensures that the query text remains intact while removing the keyword from the titles. This prevents the loss of existing entries when the user refines their query. Fixes #5.