### PR TITLE
Fix bug: Empty titles in search query results (Fixes #9)

### DIFF
--- a/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
@@ -126,7 +126,7 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
                 results.Add(new Result
                 {
                     QueryTextDisplay = query.Search,
-                    Title = string.IsNullOrEmpty(query.Search) ? SearchEngine.Name : searchQuery,
+                    Title = string.IsNullOrEmpty(searchQuery) ? SearchEngine.Name : searchQuery,
                     SubTitle = $"Search {SearchEngine.Name}",
                     IcoPath = IconPath,
                     Score = matchResults.Score,


### PR DESCRIPTION
This pull request fixes the bug where titles are empty in the list of search query results when the input only contains the shortcut term and no additional search query. The fix ensures that the query is displayed as the title in the search results.