### PR TITLE
Fix bug: Create the configuration directory if it does not exist (Fixes #11)

### DIFF
--- a/Community.PowerToys.Run.Plugin.SearchEngines/SearchEngine.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/SearchEngine.cs
@@ -59,6 +59,13 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
         /// <returns>A list of <see cref="SearchEngine"/>s</returns>
         public static List<SearchEngine> Load()
         {
+            // Create the configuration directory if it does not exist
+            string? directory = Path.GetDirectoryName(FilePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
             // If the file does not exist, return the predefined search engines
             if (!File.Exists(FilePath))
             {


### PR DESCRIPTION
Plugin fails to initialize if the `Configuration` directory does not exist. This pull request fixes the issue by creating the `Configuration` directory when checking for the `SearchEngines.json` file. This ensures that the plugin can initialize successfully even if the directory is missing. Fixes #11.