### PR TITLE
Relocate the Configuration File

### DIFF
--- a/Community.PowerToys.Run.Plugin.SearchEngines/Configuration.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/Configuration.cs
@@ -15,7 +15,15 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
         /// <summary>
         /// The path to the json configuration file that holds information about the search engines
         /// </summary>
-        public static readonly string FilePath = Path.Combine(Main.PluginDirectory, "Configuration", "SearchEngines.json");
+        public static readonly string FilePath = Path.Combine(
+            Main.PluginDirectory,
+            "..", // Plugins
+            "..", // PowerToys Run
+            "Settings",
+            "Plugins",
+            "Community.PowerToys.Run.Plugin.SearchEngines",
+            "SearchEngines.json"
+        );
 
         /// <summary>
         /// A default collection of search engines


### PR DESCRIPTION
This pull request relocates the configuration file for the PowerToys Run plugin "Community.PowerToys.Run.Plugin.SearchEngines" to the appropriate folder. The file is moved to "%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\". This change fixes issue #19.