### PR TITLE
Fix Search-Engine icon path and refactor code

### DIFF
--- a/Community.PowerToys.Run.Plugin.SearchEngines/Configuration.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/Configuration.cs
@@ -120,8 +120,8 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
 
             // Download the favicons for the search engines that do not already have one
             List<Task<bool>> tasks = SearchEngines
-                .Where(engine => !File.Exists(engine.IconPath))
-                .Select(engine => engine.DownloadFavicon(directory)).ToList();
+                .Where(engine => !File.Exists(engine.GetIconPath()))
+                .Select(engine => engine.DownloadFavicon()).ToList();
 
             // Wait for all the tasks to complete
             await Task.WhenAll(tasks);

--- a/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/Main.cs
@@ -115,7 +115,7 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
                     QueryTextDisplay = $"{SearchEngine.Shortcut} ",
                     Title = $"{SearchEngine.Name}",
                     SubTitle = $"Search {SearchEngine.Name}",
-                    IcoPath = SearchEngine.IconPath ?? IconPath,
+                    IcoPath = SearchEngine.GetIconPath() ?? IconPath,
                     Action = e =>
                     {
                         // Open the search engine in the default browser
@@ -170,7 +170,7 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
                     QueryTextDisplay = query.Search,
                     Title = string.IsNullOrEmpty(searchQuery) ? SearchEngine.Name : searchQuery,
                     SubTitle = $"Search {SearchEngine.Name}",
-                    IcoPath = SearchEngine.IconPath ?? IconPath,
+                    IcoPath = SearchEngine.GetIconPath() ?? IconPath,
                     Score = result.Score,
                     Action = e =>
                     {

--- a/Community.PowerToys.Run.Plugin.SearchEngines/SearchEngine.cs
+++ b/Community.PowerToys.Run.Plugin.SearchEngines/SearchEngine.cs
@@ -27,16 +27,26 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
         public required string Shortcut { get; set; }
 
         /// <summary>
-        /// Path to the icon of the search engine
-        /// </summary>
-        public string? IconPath { get; set; }
-
-        /// <summary>
         /// Check if the search engine object is valid
         /// </summary>
         public bool IsValid()
         {
             return !string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(Url) && !string.IsNullOrEmpty(Shortcut);
+        }
+
+        /// <summary>
+        /// Gets the path to the favicon file for the search engine
+        /// </summary>
+        /// <returns>The path to the favicon file</returns>
+        public string GetIconPath()
+        {
+            // Path to the favicon directory
+            string iconDirectory = Path.Combine(Main.PluginDirectory, "Images", "Favicon");
+            // Extract the domain from the URL. This will be used to name the favicon file locally.
+            // For example, the favicon for "https://www.google.com" will be saved as "google.png".
+            string domain = new Uri(Url).Host.Replace("www.", "");
+            // Path to the favicon file
+            return Path.Combine(iconDirectory, $"{domain}.png");
         }
 
         /// <summary>
@@ -46,20 +56,14 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
         /// A task representing the asynchronous operation.
         /// The task result is a boolean value indicating whether the favicon was successfully downloaded and saved.
         /// </returns>
-        public async Task<bool> DownloadFavicon(string directory)
+        public async Task<bool> DownloadFavicon()
         {
-            // Extract the domain from the URL. This will be used to name the favicon file locally.
-            // For example, the favicon for "https://www.google.com" will be saved as "google.png".
-            string domain = new Uri(Url).Host.Replace("www.", "");
-
             // Path to the favicon file
-            string path = Path.Combine(directory, $"{domain}.png");
-            string iconPath = Path.Combine("Images", "Favicon", $"{domain}.png");
+            string path = GetIconPath();
 
             // Check if the favicon already exists
             if (File.Exists(path))
             {
-                IconPath = iconPath;
                 return false; // We don't need to download the favicon again
             }
 
@@ -82,8 +86,6 @@ namespace Community.PowerToys.Run.Plugin.SearchEngines
                 return false; // Failed to save the favicon
             }
 
-            // Set the IconPath to the local file path of the favicon
-            IconPath = iconPath;
             return true;
         }
 


### PR DESCRIPTION
This pull request fixes the Search-Engine icon path based on the domain of the URLs. It also refactors the code by removing the IconPath property from the SearchEngine class and introducing a GetIconPath() method instead. 

I might change this back later, but right now, the `SearchEngines.json` file needs to conform to a particular shape (without IconPath) 